### PR TITLE
Add content-type: application/json to requests with body

### DIFF
--- a/lib/resty/elasticsearch.lua
+++ b/lib/resty/elasticsearch.lua
@@ -57,8 +57,10 @@ function _M._perform_request(self, http_method, url, params, body)
         url = url .. ngx.encode_args(params)
     end
 
+    local headers = {}
     if body then
         body = cjson.encode(body)
+        headers['Content-Type'] = 'application/json'
     else
         body = ''
     end
@@ -69,7 +71,8 @@ function _M._perform_request(self, http_method, url, params, body)
     local res, err = http_c:request({
         path = url,
         method = http_method,
-        body = body
+        body = body,
+        headers = headers
     })
 
     if not res then


### PR DESCRIPTION
I would like to add a necessary header required by ES6.

https://www.elastic.co/blog/strict-content-type-checking-for-elasticsearch-rest-requests

I couldn't get this to work, so I jumped into the code and made the quick fix. Please let me know how you like it and publish it to OPM when you can!

