### PR TITLE
Bugfix for `get_err_str` function

### DIFF
--- a/lib/resty/es/utils.lua
+++ b/lib/resty/es/utils.lua
@@ -31,10 +31,10 @@ local function json_decode(str)
 end
 
 
-function _M.get_err_str(self, http_response_code, http_response_data)
+function _M.get_err_str(http_response_code, http_response_data)
     return str_format(
-        '%s: http response code: %s. and es response error info: %s',
-        http_resonse_code, http_response_data
+        'Http response code: %s. and es response error info: %s',
+        http_response_code, http_response_data
     )
 end
 


### PR DESCRIPTION
Fix bug with
```
resty/elasticsearch.lua:83: bad argument #4 to 'get_err_str' (no value)
```
* remove odd argument `self`
* fix typo with `http_resonse_code`
* fix fromat